### PR TITLE
Check for Python presence

### DIFF
--- a/src/commands/check-vulnerabilities.yml
+++ b/src/commands/check-vulnerabilities.yml
@@ -61,6 +61,11 @@ parameters:
 
 steps:
   - run:
+    name: Check for Python presence
+    command: |
+      ls <<parameters.python-path>>
+
+  - run:
       name: Install Python modules
       command: |
         if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
@@ -118,4 +123,4 @@ steps:
         if (vulns_open > <<parameters.vulnerability-threshold>>):
          print("Above the vulnerabilities threshold. Failing build.")
          sys.exit(1)
-        
+


### PR DESCRIPTION
Fixes #5 

Added a `ls` check, since the orb relies on `parameters.python-path` the build will now fail if no file is found at `parameters.python-path`